### PR TITLE
Add visibility attribute

### DIFF
--- a/MASPreferencesWindowController.h
+++ b/MASPreferencesWindowController.h
@@ -11,6 +11,7 @@
 
 extern NSString *const kMASPreferencesWindowControllerDidChangeViewNotification;
 
+__attribute__((__visibility__("default")))
 #if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5
 @interface MASPreferencesWindowController : NSWindowController <NSToolbarDelegate, NSWindowDelegate>
 #else


### PR DESCRIPTION
Starting with 64 bit, all object/class access happen through a variable which respect the `-fvisibility` compiler option (which I have set to `hidden` to avoid accidentally leaking private symbols).

For more info see [Apple’s release notes](https://developer.apple.com/library/mac/releasenotes/Cocoa/RN-ObjectiveC/_index.html#//apple_ref/doc/uid/TP40004309-CH1-SW1).
