### PR TITLE
If the first view controller is NSNull, the selected view controller is incorrectly set on first launch.

### DIFF
--- a/MASPreferencesWindowController.m
+++ b/MASPreferencesWindowController.m
@@ -66,7 +66,7 @@ static NSString *const PreferencesKeyForViewBounds (NSString *identifier)
         [[self window] setTitle:self.title];
 
     if ([self.viewControllers count])
-        self.selectedViewController = [self viewControllerForIdentifier:[[NSUserDefaults standardUserDefaults] stringForKey:kMASPreferencesSelectedViewKey]] ?: [self.viewControllers objectAtIndex:0];
+        self.selectedViewController = [self viewControllerForIdentifier:[[NSUserDefaults standardUserDefaults] stringForKey:kMASPreferencesSelectedViewKey]] ?: [self firstViewController];
 
     NSString *origin = [[NSUserDefaults standardUserDefaults] stringForKey:kMASPreferencesFrameTopLeftKey];
     if (origin)
@@ -74,6 +74,14 @@ static NSString *const PreferencesKeyForViewBounds (NSString *identifier)
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidMove:)   name:NSWindowDidMoveNotification object:self.window];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResize:) name:NSWindowDidResizeNotification object:self.window];
+}
+
+- (NSViewController <MASPreferencesViewController> *)firstViewController {
+    for (id viewController in self.viewControllers)
+        if ([viewController isKindOfClass:[NSViewController class]])
+            return viewController;
+
+    return nil;
 }
 
 #pragma mark -


### PR DESCRIPTION
I ran into a problem when centring my preference toolbar items using an NSNull on both sides. On first launch of the application there were no User Defaults available so it defaulted to selecting the first view controller, which in my case was NSNull. I switched it up to default to the first subclass of NSViewController.

Let me know if something looks off.
