### PR TITLE
Added Option to update the window table with the controller's title

### DIFF
--- a/MASPreferencesWindowController.h
+++ b/MASPreferencesWindowController.h
@@ -31,6 +31,7 @@ __attribute__((__visibility__("default")))
 @property (nonatomic, readonly, retain) NSViewController <MASPreferencesViewController> *selectedViewController;
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, retain) IBOutlet NSToolbar *toolbar;
+@property (nonatomic) BOOL useTabTitle;
 
 - (id)initWithViewControllers:(NSArray *)viewControllers;
 - (id)initWithViewControllers:(NSArray *)viewControllers title:(NSString *)title;

--- a/MASPreferencesWindowController.m
+++ b/MASPreferencesWindowController.m
@@ -254,7 +254,11 @@ static NSString *const PreferencesKeyForViewBounds (NSString *identifier)
     }
 
     [[self.window toolbar] setSelectedItemIdentifier:controller.identifier];
-
+    if( self.useTabTitle )
+    {
+        [self.window setTitle:controller.title?:@""];
+    }
+    
     // Record new selected controller in user defaults
     [[NSUserDefaults standardUserDefaults] setObject:controller.identifier forKey:kMASPreferencesSelectedViewKey];
     


### PR DESCRIPTION
Added a new option (disabled by default) to set the title of the Window when a tab is selected.
This is to mimic the behaviour of most Apple's apps.
