### PR TITLE
fix the crash caused by reference to dealloced object

### DIFF
--- a/MASPreferencesWindowController.h
+++ b/MASPreferencesWindowController.h
@@ -30,7 +30,7 @@ __attribute__((__visibility__("default")))
 @property (nonatomic, readonly) NSUInteger indexOfSelectedController;
 @property (nonatomic, readonly, retain) NSViewController <MASPreferencesViewController> *selectedViewController;
 @property (nonatomic, readonly) NSString *title;
-@property (nonatomic, retain) IBOutlet NSToolbar *toolbar;
+@property (nonatomic, weak) IBOutlet NSToolbar *toolbar;
 
 - (id)initWithViewControllers:(NSArray *)viewControllers;
 - (id)initWithViewControllers:(NSArray *)viewControllers title:(NSString *)title;

--- a/MASPreferencesWindowController.m
+++ b/MASPreferencesWindowController.m
@@ -52,6 +52,11 @@ static NSString *const PreferencesKeyForViewBounds (NSString *identifier)
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[self window] setDelegate:nil];
+    for (NSToolbarItem *item in [self.toolbar items]) {
+        item.target = nil;
+        item.action = nil;
+    }
+    self.toolbar.delegate = nil;
 #if !__has_feature(objc_arc)
     [_viewControllers release];
     [_selectedViewController release];


### PR DESCRIPTION
If the preference controller is released, the application crashes due to reference to realloced MASPreferenceWindowController object.
