### PR TITLE
Fix 32 bit compilation problem

### DIFF
--- a/MASPreferencesWindowController.h
+++ b/MASPreferencesWindowController.h
@@ -23,7 +23,7 @@ __attribute__((__visibility__("default")))
     NSMutableDictionary *_minimumViewRects;
     NSString *_title;
     NSViewController <MASPreferencesViewController> *_selectedViewController;
-	IBOutlet NSToolbar *_toolbar;
+	NSToolbar *_toolbar;
 }
 
 @property (nonatomic, readonly) NSMutableArray *viewControllers;

--- a/MASPreferencesWindowController.h
+++ b/MASPreferencesWindowController.h
@@ -23,7 +23,7 @@ __attribute__((__visibility__("default")))
     NSMutableDictionary *_minimumViewRects;
     NSString *_title;
     NSViewController <MASPreferencesViewController> *_selectedViewController;
-	IBOutlet NSToolbar *toolbar;
+	IBOutlet NSToolbar *_toolbar;
 }
 
 @property (nonatomic, readonly) NSMutableArray *viewControllers;


### PR DESCRIPTION
With Xcode 6.1.1 and OS X 10.10.1, we get an error when we compile a 32 bit program:
" MASPreferencesWindowController.m:29:13: Synthesized property 'toolbar' must either be named the same as a compatible instance variable or must explicitly name an instance variable "