### PR TITLE
Import Cocoa in the header.

### DIFF
--- a/MASPreferencesViewController.h
+++ b/MASPreferencesViewController.h
@@ -2,6 +2,8 @@
 // Any controller providing preference pane view must support this protocol
 //
 
+#import <Cocoa/Cocoa.h>
+
 @protocol MASPreferencesViewController <NSObject>
 
 @optional


### PR DESCRIPTION
This enables the use of MASPreferences without a `.pch` file.