### PR TITLE
ARCBridge header

### DIFF
--- a/Framework/ARCBridge.h
+++ b/Framework/ARCBridge.h
@@ -1,0 +1,50 @@
+#ifndef PPMacho_ARCBridge_h
+#define PPMacho_ARCBridge_h
+#include <AvailabilityMacros.h>
+
+#if __has_feature(objc_arc)
+
+#define SUPERDEALLOC
+#define RELEASEOBJ(obj)
+#define RETAINOBJ(obj) obj
+#define RETAINOBJNORETURN(obj)
+#define AUTORELEASEOBJ(obj) obj
+#define AUTORELEASEOBJNORETURN(obj)
+#define BRIDGE(toType, obj) (__bridge toType)(obj)
+#define arcstrong strong
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7
+#define arcweak weak
+#define __arcweak __weak
+#else
+#define arcweak unsafe_unretained
+#define __arcweak __unsafe_unretained
+#endif
+
+#else
+
+#define SUPERDEALLOC [super dealloc]
+#define RELEASEOBJ(obj) [obj release]
+#define RETAINOBJ(obj) [obj retain]
+#define RETAINOBJNORETURN(obj) [obj retain]
+#define AUTORELEASEOBJ(obj) [obj autorelease]
+#define AUTORELEASEOBJNORETURN(obj) [obj autorelease]
+#define BRIDGE(toType, obj) (toType)obj
+
+#ifdef __OBJC_GC__
+#define arcstrong strong
+#define arcweak weak
+#define __arcweak __weak
+#else
+#define arcstrong retain
+#define arcweak assign
+#define __arcweak
+#endif
+
+#endif
+
+#define arcretain arcstrong
+
+// Other useful functions for ARC/CoreFoundation data exchange:
+// CFBridgingRetain(), CFBridgingRelease()
+
+#endif

--- a/Framework/MASPreferencesWindowController.m
+++ b/Framework/MASPreferencesWindowController.m
@@ -1,4 +1,5 @@
 #import "MASPreferencesWindowController.h"
+#import "ARCBridge.h"
 
 NSString *const kMASPreferencesWindowControllerDidChangeViewNotification = @"MASPreferencesWindowControllerDidChangeViewNotification";
 
@@ -39,10 +40,7 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
     NSString *nibPath = [[NSBundle bundleForClass:MASPreferencesWindowController.class] pathForResource:@"MASPreferencesWindow" ofType:@"nib"];
     if ((self = [super initWithWindowNibPath:nibPath owner:self]))
     {
-		_viewControllers = [NSMutableArray arrayWithArray: viewControllers];
-#if !__has_feature(objc_arc)
-        _viewControllers = [_viewControllers retain];
-#endif
+		_viewControllers = RETAINOBJ([NSMutableArray arrayWithArray: viewControllers]);
         _minimumViewRects = [[NSMutableDictionary alloc] init];
         _title = [title copy];
     }
@@ -176,10 +174,7 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
         toolbarItem.target = self;
         toolbarItem.action = @selector(toolbarItemDidClick:);
     }
-#if !__has_feature(objc_arc)
-    [toolbarItem autorelease];
-#endif
-    return toolbarItem;
+    return AUTORELEASEOBJ(toolbarItem);
 }
 
 #pragma mark -
@@ -211,20 +206,14 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
             return;
         }
 
-#if __has_feature(objc_arc)
-        [self.window setContentView:[[NSView alloc] init]];
-#else
-        [self.window setContentView:[[[NSView alloc] init] autorelease]];
-#endif
+        [self.window setContentView:AUTORELEASEOBJ([[NSView alloc] init])];
         [_selectedViewController setNextResponder:nil];
         // With 10.10 and later AppKit will invoke viewDidDisappear so we need to prevent it from being called twice.
         if (![NSViewController instancesRespondToSelector:@selector(viewDidDisappear)])
             if ([_selectedViewController respondsToSelector:@selector(viewDidDisappear)])
                 [_selectedViewController viewDidDisappear];
 
-#if !__has_feature(objc_arc)
-        [_selectedViewController release];
-#endif
+        RELEASEOBJ(_selectedViewController);
         _selectedViewController = nil;
     }
 
@@ -278,11 +267,7 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
 
     [self.window setFrame:newFrame display:YES animate:[self.window isVisible]];
     
-#if __has_feature(objc_arc)
-    _selectedViewController = controller;
-#else
-    _selectedViewController = [controller retain];
-#endif
+    _selectedViewController = RETAINOBJ(controller);
     // In OSX 10.10, setContentView below calls viewWillAppear.  We still want to call viewWillAppear on < 10.10,
     // so the check below avoids calling viewWillAppear twice on 10.10.
     // See https://github.com/shpakovski/MASPreferences/issues/32 for more info.

--- a/MASPreferences.xcodeproj/project.pbxproj
+++ b/MASPreferences.xcodeproj/project.pbxproj
@@ -7,14 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F16AF8081BA27AFD0022155C /* MASPreferencesWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = F16AF8001BA27AFD0022155C /* MASPreferencesWindow.xib */; settings = {ASSET_TAGS = (); }; };
+		55050B571C515AEA00C21789 /* ARCBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 55050B561C515AEA00C21789 /* ARCBridge.h */; };
+		F16AF8081BA27AFD0022155C /* MASPreferencesWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = F16AF8001BA27AFD0022155C /* MASPreferencesWindow.xib */; };
 		F16AF80A1BA27AFD0022155C /* MASPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = F16AF8031BA27AFD0022155C /* MASPreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F16AF80B1BA27AFD0022155C /* MASPreferencesViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F16AF8051BA27AFD0022155C /* MASPreferencesViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F16AF80C1BA27AFD0022155C /* MASPreferencesWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = F16AF8061BA27AFD0022155C /* MASPreferencesWindowController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F16AF80D1BA27AFD0022155C /* MASPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F16AF8071BA27AFD0022155C /* MASPreferencesWindowController.m */; settings = {ASSET_TAGS = (); }; };
+		F16AF80D1BA27AFD0022155C /* MASPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F16AF8071BA27AFD0022155C /* MASPreferencesWindowController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		55050B561C515AEA00C21789 /* ARCBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARCBridge.h; sourceTree = "<group>"; };
 		F16AF7F41BA279F10022155C /* MASPreferences.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MASPreferences.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F16AF8011BA27AFD0022155C /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MASPreferencesWindow.xib; sourceTree = "<group>"; };
 		F16AF8021BA27AFD0022155C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 		F16AF7FF1BA27AFD0022155C /* Framework */ = {
 			isa = PBXGroup;
 			children = (
+				55050B561C515AEA00C21789 /* ARCBridge.h */,
 				F16AF8051BA27AFD0022155C /* MASPreferencesViewController.h */,
 				F16AF8061BA27AFD0022155C /* MASPreferencesWindowController.h */,
 				F16AF8071BA27AFD0022155C /* MASPreferencesWindowController.m */,
@@ -73,6 +76,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55050B571C515AEA00C21789 /* ARCBridge.h in Headers */,
 				F16AF80A1BA27AFD0022155C /* MASPreferences.h in Headers */,
 				F16AF80C1BA27AFD0022155C /* MASPreferencesWindowController.h in Headers */,
 				F16AF80B1BA27AFD0022155C /* MASPreferencesViewController.h in Headers */,


### PR DESCRIPTION
Include and use the ARCBridge.h header: This makes the code a bit cleaner to read, without the ifdefs all over.

The only place I didn't replace the ifdefs were in the dealloc function, as there isn't that much need to replace those.