### PR TITLE
Adds Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ profile
 *.moved-aside
 # Finder
 .DS_Store
+# Carthage
+Carthage/Build


### PR DESCRIPTION
This is to ease working with MASPreferences with Carthage with its `--use-submodules` flag turned on (which can lead in certain situations to a `Carthage/Build` directory under MASPreferences even if it's used as a dependency).