### PR TITLE
Various updates for modern macOS.

### DIFF
--- a/Framework/MASPreferencesWindowController.h
+++ b/Framework/MASPreferencesWindowController.h
@@ -21,11 +21,7 @@ extern NSString * const kMASPreferencesWindowControllerDidChangeViewNotification
  * Window controller for managing Preference view controllers.
  */
 __attribute__((__visibility__("default")))
-#if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5
 @interface MASPreferencesWindowController : NSWindowController <NSToolbarDelegate, NSWindowDelegate>
-#else
-@interface MASPreferencesWindowController : NSWindowController
-#endif
 {
 @private
     NSMutableArray *_viewControllers;

--- a/Framework/MASPreferencesWindowController.m
+++ b/Framework/MASPreferencesWindowController.m
@@ -93,6 +93,12 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
         [self.window setFrameTopLeftPoint:NSPointFromString(origin)];
     }
 
+#ifdef MAC_OS_VERSION_11_0
+    if (@available(macOS 11.0, *)) {
+        [self.window setToolbarStyle:NSWindowToolbarStylePreference];
+    }
+#endif
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidMove:)   name:NSWindowDidMoveNotification object:self.window];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResize:) name:NSWindowDidResizeNotification object:self.window];
 }

--- a/Framework/MASPreferencesWindowController.m
+++ b/Framework/MASPreferencesWindowController.m
@@ -39,7 +39,7 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
 - (instancetype)initWithViewControllers:(NSArray *)viewControllers title:(NSString *)title
 {
 	NSParameterAssert(viewControllers.count > 0);
-    NSString *nibPath = [[NSBundle bundleForClass:MASPreferencesWindowController.class] pathForResource:@"MASPreferencesWindow" ofType:@"nib"];
+    NSString *nibPath = [[MASPreferencesWindowController resourceBundle] pathForResource:@"MASPreferencesWindow" ofType:@"nib"];
     if ((self = [super initWithWindowNibPath:nibPath owner:self]))
     {
 		_viewControllers = [viewControllers mutableCopy];
@@ -343,6 +343,14 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
     while ([_viewControllers objectAtIndex:selectedIndex] == [NSNull null]);
 
     [self selectControllerAtIndex:selectedIndex];
+}
+
+#pragma mark -
+#pragma mark Helper Functions
+
++ (NSBundle *)resourceBundle {
+    NSBundle *moduleBundle = [NSBundle bundleForClass:MASPreferencesWindowController.class];
+    return [NSBundle bundleWithURL:[NSURL fileURLWithPath:[moduleBundle pathForResource:@"MASPreferences" ofType:@"bundle"]]];
 }
 
 @end

--- a/MASPreferences.podspec
+++ b/MASPreferences.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.platform              = :osx
+  s.platform              = :osx, '10.10'
   s.name                  = "MASPreferences"
   s.version               = "1.3"
   s.summary               = "Modern implementation of the Preferences window for OS X apps, used in TextMate, GitBox and Mou."

--- a/MASPreferences.podspec
+++ b/MASPreferences.podspec
@@ -8,7 +8,9 @@ Pod::Spec.new do |s|
   s.author                = { "Vadim Shpakovski" => "vadim@shpakovski.com" }
   s.source                = { :git => 'https://github.com/shpakovski/MASPreferences.git', :tag => '1.3' }
   s.source_files          = 'Framework/*.{h,m}'
-  s.resources             = 'Framework/en.lproj/*.xib'
+  s.resource_bundles      = {
+    'MASPreferences' => ['Framework/en.lproj/*.xib']
+  }
   s.exclude_files         = 'README.md', 'LICENSE.md', 'MASPreferences.podspec'
   s.requires_arc          = true
 end


### PR DESCRIPTION
This PR:
1. Use resource bundle to support static linkage for CocoaPods.
2. Update podspec to minimum target platform to OS X 10.10 to remove warnings, since this projects now uses methods requiring 10.10.
3. Use preference style for window toolbar for macOS 11.0+.