### PR TITLE
Add support for Swift Package Manager.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ profile
 .DS_Store
 # Carthage
 Carthage/Build
+# Swift Package Manager
+.swiftpm

--- a/Framework/Headers/MASPreferences.h
+++ b/Framework/Headers/MASPreferences.h
@@ -1,0 +1,1 @@
+../MASPreferences.h

--- a/Framework/Headers/MASPreferences.modulemap
+++ b/Framework/Headers/MASPreferences.modulemap
@@ -1,0 +1,1 @@
+../MASPreferences.modulemap

--- a/Framework/Headers/MASPreferencesViewController.h
+++ b/Framework/Headers/MASPreferencesViewController.h
@@ -1,0 +1,1 @@
+../MASPreferencesViewController.h

--- a/Framework/Headers/MASPreferencesWindowController.h
+++ b/Framework/Headers/MASPreferencesWindowController.h
@@ -1,0 +1,1 @@
+../MASPreferencesWindowController.h

--- a/Framework/MASPreferencesWindowController.m
+++ b/Framework/MASPreferencesWindowController.m
@@ -355,8 +355,12 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
 #pragma mark Helper Functions
 
 + (NSBundle *)resourceBundle {
+#ifdef SWIFT_PACKAGE
+    return SWIFTPM_MODULE_BUNDLE;
+#else
     NSBundle *moduleBundle = [NSBundle bundleForClass:MASPreferencesWindowController.class];
     return [NSBundle bundleWithURL:[NSURL fileURLWithPath:[moduleBundle pathForResource:@"MASPreferences" ofType:@"bundle"]]];
+#endif
 }
 
 @end

--- a/MASPreferences.podspec
+++ b/MASPreferences.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.platform              = :osx, '10.10'
   s.name                  = "MASPreferences"
-  s.version               = "1.3"
+  s.version               = "1.4"
   s.summary               = "Modern implementation of the Preferences window for OS X apps, used in TextMate, GitBox and Mou."
   s.homepage              = "https://github.com/shpakovski/MASPreferences"
   s.license               = { :type => 'BSD', :file => 'LICENSE.md' }
   s.author                = { "Vadim Shpakovski" => "vadim@shpakovski.com" }
-  s.source                = { :git => 'https://github.com/shpakovski/MASPreferences.git', :tag => '1.3' }
+  s.source                = { :git => 'https://github.com/shpakovski/MASPreferences.git', :tag => '1.4' }
   s.source_files          = 'Framework/*.{h,m}'
   s.resource_bundles      = {
     'MASPreferences' => ['Framework/en.lproj/*.xib']

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "MASPreferences",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v10_10),
+    ],
+    products: [
+        .library(name: "MASPreferences",
+                 targets: ["MASPreferences"])
+    ],
+    targets: [
+        .target(
+            name: "MASPreferences",
+            path: "./Framework",
+            exclude: [
+                "Info.plist",
+                "MASPreferences.modulemap",
+            ],
+            resources: [],
+            publicHeadersPath: "./Headers"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This component is intended as a replacement for SS_PrefsController by Matt Legen
 You can find a Demo project at [MASPreferencesDemo](https://github.com/shpakovski/MASPreferencesDemo).
 
 # Install
+
 #### [Carthage](https://github.com/Carthage/Carthage)
 
 - Add `github "shpakovski/MASPreferences"` to your Cartfile.
@@ -14,3 +15,7 @@ You can find a Demo project at [MASPreferencesDemo](https://github.com/shpakovsk
 #### [CocoaPods](https://github.com/cocoapods/cocoapods)
 
 - Add `pod 'MASPreferences'` to your Podfile.
+
+#### [Swift Package Manager](https://www.swift.org/package-manager/)
+
+- Add `.package(url: "https://github.com/shpakovski/MASPreferences.git", .upToNextMajor(from: "1.4"))` to your Package.swift.


### PR DESCRIPTION
This PR adds support for Swift Package Manager.

I've also updated the version number to 1.4 (new features with no breaking changes) and could you mind tagging a release so that SPM projects can reference this framework?