### PR TITLE
Fix a resource bundle resolving issue introduced in #61.

### DIFF
--- a/Framework/MASPreferencesWindowController.m
+++ b/Framework/MASPreferencesWindowController.m
@@ -359,7 +359,17 @@ static NSString * PreferencesKeyForViewBounds (NSString *identifier)
     return SWIFTPM_MODULE_BUNDLE;
 #else
     NSBundle *moduleBundle = [NSBundle bundleForClass:MASPreferencesWindowController.class];
-    return [NSBundle bundleWithURL:[NSURL fileURLWithPath:[moduleBundle pathForResource:@"MASPreferences" ofType:@"bundle"]]];
+
+    // Lookup for MASPreferences.bundle, which usually comes with CocoaPods's `:linkage => :static`.
+    NSString *resourceBundlePath = [moduleBundle pathForResource:@"MASPreferences" ofType:@"bundle"];
+    if ([resourceBundlePath length]) {
+        NSBundle *resourceBundle = [NSBundle bundleWithURL:[NSURL fileURLWithPath:resourceBundlePath]];
+        if (resourceBundle) {
+            return resourceBundle;
+        }
+    }
+
+    return moduleBundle;
 #endif
 }
 

--- a/MASPreferences.podspec
+++ b/MASPreferences.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.platform              = :osx, '10.10'
   s.name                  = "MASPreferences"
-  s.version               = "1.4"
+  s.version               = "1.4.1"
   s.summary               = "Modern implementation of the Preferences window for OS X apps, used in TextMate, GitBox and Mou."
   s.homepage              = "https://github.com/shpakovski/MASPreferences"
   s.license               = { :type => 'BSD', :file => 'LICENSE.md' }
   s.author                = { "Vadim Shpakovski" => "vadim@shpakovski.com" }
-  s.source                = { :git => 'https://github.com/shpakovski/MASPreferences.git', :tag => '1.4' }
+  s.source                = { :git => 'https://github.com/shpakovski/MASPreferences.git', :tag => '1.4.1' }
   s.source_files          = 'Framework/*.{h,m}'
   s.resource_bundles      = {
     'MASPreferences' => ['Framework/en.lproj/*.xib']

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ You can find a Demo project at [MASPreferencesDemo](https://github.com/shpakovsk
 
 #### [Swift Package Manager](https://www.swift.org/package-manager/)
 
-- Add `.package(url: "https://github.com/shpakovski/MASPreferences.git", .upToNextMajor(from: "1.4"))` to your Package.swift.
+- Add `.package(url: "https://github.com/shpakovski/MASPreferences.git", .upToNextMajor(from: "1.4.1"))` to your Package.swift.


### PR DESCRIPTION
The latest commit works well with Swift Package Manager and CocoaPods's static linkage, but the resource bundle resolving logic introduced in #61 seems to break other use cases. Here is a quick fix.

Also, releases should be tagged as '1.4.0' since SPM are particular about the version tag. It might be reasonable to make another tag as '1.4.1' and I can help to test it again.